### PR TITLE
fix: only match a-z, A-Z, $ and _

### DIFF
--- a/src/Commands/Types/GenerateTypesCommand.ts
+++ b/src/Commands/Types/GenerateTypesCommand.ts
@@ -71,7 +71,7 @@ export class GenerateTypesCommand extends Command {
 							.trim()
 							.split(':')[1]
 
-						if (options) {
+						if (options && /[a-zA-Z\$\_]/.test(prop[0])) {
 							options = options.split('|')
 
 							options.forEach((option, position) => {


### PR DESCRIPTION
## Fixes
* only match acceptable chars